### PR TITLE
Clarify virtualenv activation for Windows and Linux/macOS

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -19,7 +19,10 @@ Once uv is intalled, you can install the project dependencies. First of all, let
 
 ```bash
 uv venv .venv
+# macOS / Linux
 . .venv/bin/activate # or source .venv/bin/activate
+# Windows
+. .\.venv\Scripts\Activate.ps1 # or .\.venv\Scripts\activate
 uv pip install -e .
 ```
 Just to make sure that everything is working, simply run the following command:


### PR DESCRIPTION
Improved the activation instructions for the virtual environment in `docs/GETTING_STARTED.md`.

Separated platform-specific commands for:
- macOS/Linux
- Windows PowerShell and CMD

This helps Windows users avoid common errors when using `source`.